### PR TITLE
Master

### DIFF
--- a/projects/control-schema/src/lib/input/identifier/identifier-input.component.ts
+++ b/projects/control-schema/src/lib/input/identifier/identifier-input.component.ts
@@ -6,7 +6,7 @@ import { InputControl } from '../input.control';
 import { IdentifierValue } from './identifier-value';
 
 /**
- * Represents a control that allows the writing of a identifier. 
+ * Represents a control that allows the writing of an identifier. 
  */
 @Component({
     selector: 'input-identifier',

--- a/projects/control-schema/src/lib/utils/helpers.ts
+++ b/projects/control-schema/src/lib/utils/helpers.ts
@@ -20,6 +20,14 @@ export type Params<T> = {
 };
 
 /**
+ * An object of paths that is used to get the child controls in a `FormGroup`/`FormArray` control. 
+ * The value of its properties is a dot-delimited string value that defines the path to a child control. 
+ */
+export type ChildControlsPath = {
+    [key: string]: string;
+};
+
+/**
  * Returns true if the specified `possDescendant` is descendant from the specified `ancestorName`; 
  * otherwise, false. 
  * @param possDescendant Possible descendant. 

--- a/projects/control-schema/src/lib/utils/helpers.ts
+++ b/projects/control-schema/src/lib/utils/helpers.ts
@@ -21,10 +21,11 @@ export type Params<T> = {
 
 /**
  * An object of paths that is used to get the child controls in a `FormGroup`/`FormArray` control. 
- * The value of its properties is a dot-delimited string value that defines the path to a child control. 
+ * The value of its properties is a dot-delimited string value or an array of string/number values 
+ * that define the path to a child control. 
  */
-export type ChildControlsPath = {
-    [key: string]: string;
+ export type ChildControlsPath = {
+    [key: string]: Array<string | number> | string;
 };
 
 /**

--- a/projects/control-schema/src/lib/utils/validator.ts
+++ b/projects/control-schema/src/lib/utils/validator.ts
@@ -1,6 +1,6 @@
 
 import { Directive, OnChanges, Input, SimpleChanges } from '@angular/core';
-import { AbstractControl, FormControl, ValidatorFn, ValidationErrors, Validator, NG_VALIDATORS, FormGroup } from '@angular/forms';
+import { AbstractControl, FormControl, ValidatorFn, ValidationErrors, Validator, NG_VALIDATORS, FormGroup, FormArray } from '@angular/forms';
 
 /**
  * Represents a class that contains a boolean property named `required`. 
@@ -60,6 +60,38 @@ export class ExtraValidators
 
         return res;
     }
+
+    /**
+     * @description
+     * Validator that is applied to `FormArray` controls. It requires that the amount of 
+	 * `FormArray`'s child controls to be greater than or equal to the provided minimum length. 
+	 * The validator exists only as a function and not as a directive. 
+     *
+     * @usageNotes
+     *
+     * ### Validates that the `FormArray` field has a minimum of 2 child controls: 
+     *
+     * ```typescript 
+     * const formArrayControl = new FormArray([new FormControl('ng')], ExtraValidators.minLength(2)); 
+     *
+	 * console.log(formArrayControl.errors); // { minLength: { requiredLength: 2, actualLength: 1 } } 
+     * ``` 
+     *
+     * @returns A validator function that returns an error map with the 
+     * `minLength` if the validation check fails, otherwise `null`. 
+     */
+    public static minLength(minLength: number): ValidatorFn
+    {
+        const res = (control: FormArray): ValidationErrors | null => {
+            const len: number = control.controls.length;
+
+            return (len < minLength) 
+                ? { 'minLength': { 'requiredLength': minLength, 'actualLength': len } } 
+                : null;
+        };
+
+        return res;
+	}
 
     /**
      * @description


### PR DESCRIPTION
**Información de cambios en el proyecto "control-schema" con respecto a la tarea "Adición de Repositorios al Catálogo de Sceiba"**
 - Adicioné el validador `minLength` en el fichero `utils\validator.ts`. 
    * El validador `minLength` es aplicado a los controles `FormArray` solamente. 
 - Adicioné el tipo `ChildControlsPath` en el fichero `utils\helpers.ts`. 
    * El tipo `ChildControlsPath` representa un objeto de caminos que es usado para obtener los controles hijos en un control `FormGroup` / `FormArray`. El valor de sus propiedades es un valor de cadena delimitado por puntos que define el camino a un control hijo. 
